### PR TITLE
Fix missing assignment in 'Type e Interfaces'

### DIFF
--- a/Content/3-Conteudo-Principal/Type-e-Interfaces.md
+++ b/Content/3-Conteudo-Principal/Type-e-Interfaces.md
@@ -85,7 +85,7 @@ interface Geladeira {
 }
 
 // declarando um objeto do tipo Geladeira 
-const Brastemp: Geladeira {
+const Brastemp: Geladeira = {
   nome: "Brastemp Frost Free",
   descricao: "Geladeira bonita",
   modelo: "1231XHDDH"


### PR DESCRIPTION
O objeto 'Brastemp' não recebia a atribuição com sinal de igual, como nunca atribuí nada com a "tipagem" de interface no typescript, decidi investigar e checar se era uma característica ou um erro de digitação na hora de criar o exemplo. Obrigado! 